### PR TITLE
Add UIAdaptivePresentationControllerDelegate and test out dismiss

### DIFF
--- a/testFirstResponder/Base.lproj/Main.storyboard
+++ b/testFirstResponder/Base.lproj/Main.storyboard
@@ -38,7 +38,7 @@
                     <navigationItem key="navigationItem" id="LYb-gB-5MY">
                         <barButtonItem key="rightBarButtonItem" title="Show" id="bZZ-Kf-8PX">
                             <connections>
-                                <segue destination="OY6-0Z-Kvx" kind="popoverPresentation" popoverAnchorBarButtonItem="bZZ-Kf-8PX" id="rYI-T3-5ca">
+                                <segue destination="OY6-0Z-Kvx" kind="popoverPresentation" identifier="showSegue" popoverAnchorBarButtonItem="bZZ-Kf-8PX" id="rYI-T3-5ca">
                                     <popoverArrowDirection key="popoverArrowDirection" up="YES" down="YES" left="YES" right="YES"/>
                                 </segue>
                             </connections>

--- a/testFirstResponder/TableViewController.swift
+++ b/testFirstResponder/TableViewController.swift
@@ -46,10 +46,10 @@ class TableViewController: UITableViewController {
             })
         case .some("modal"):
             print("TTT popover modal")
+            UIApplication.shared.sendAction(.modal, to: nil, from: self, for: nil)
             dismiss(animated: true, completion: { [weak self] in
                 guard let self = self else { return }
                 print("TTT popover animated dismiss completion")
-                UIApplication.shared.sendAction(.modal, to: nil, from: self, for: nil)
             })
         case .some(let identifier):
             fatalError("Not handled \(identifier)")

--- a/testFirstResponder/ViewController.swift
+++ b/testFirstResponder/ViewController.swift
@@ -13,6 +13,13 @@ private extension Selector {
 }
 class ViewController: UIViewController {
 
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "showSegue" {
+            let destination = segue.destination
+            destination.popoverPresentationController?.delegate = self
+        }
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
@@ -34,8 +41,11 @@ class ViewController: UIViewController {
     }
 
     @IBAction func modal(_ sender: Any) {
+        let vc: UIViewController = .rootNav
         print("TTT vc modal")
-        self.present(.rootNav, animated: true, completion: nil)
+        self.present(vc, animated: true, completion: nil)
+        print("TTT vc modal \(vc.presentationController)")
+        vc.presentationController?.delegate = self
     }
 
     @IBAction func dismiss(_ sender: Any) {
@@ -44,5 +54,17 @@ class ViewController: UIViewController {
 
     override var canBecomeFirstResponder: Bool {
         return true
+    }
+}
+
+extension ViewController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        Swift.print("TTT didDismiss \(presentationController)")
+    }
+}
+
+extension ViewController: UIPopoverPresentationControllerDelegate {
+    func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {
+        Swift.print("TTT presentationControllerDidAttemptToDismiss \(presentationController)")
     }
 }


### PR DESCRIPTION
Testing whether conforming to `UIAdaptivePresentationControllerDelegate` would properly call dismiss.

Looks like `UIAdaptivePresentationControllerDelegate.presentationControllerDidDismiss(_ presentationController:)` will only be called when user drag away from the dialog, and not with manual dismiss.

```
    // Called on the delegate when the user has taken action to dismiss the presentation successfully, after all animations are finished.
    // This is not called if the presentation is dismissed programatically.
    @available(iOS 13.0, *)
    optional func presentationControllerDidDismiss(_ presentationController: UIPresentationController)
```